### PR TITLE
Fixes a few spelling mistakes in instructions for lab101 and lab103

### DIFF
--- a/optaplanner-training-docs/src/main/asciidoc/lab101/lab101-solution.adoc
+++ b/optaplanner-training-docs/src/main/asciidoc/lab101/lab101-solution.adoc
@@ -22,7 +22,7 @@ end
 ==== Pitfalls
 
 A computer that has 6 processes is worse than a computer that has 5 processes.
-The score function should reflect that, even if the customer's business annalist does not want to think
+The score function should reflect that, even if the customer's business analyst does not want to think
 about any solution for which a computer has more than 4 computers (because it's an infeasible solution).
 
 This code might trigger a http://docs.jboss.org/drools/release/latest/optaplanner-docs/html_single/index.html#scoreTrap[score trap]:

--- a/optaplanner-training-docs/src/main/asciidoc/lab103/lab103.adoc
+++ b/optaplanner-training-docs/src/main/asciidoc/lab103/lab103.adoc
@@ -15,7 +15,7 @@ But there are differences:
 .. VM parameters (optional): +-Xmx512M -server+
 .. Working directory: +optaplanner-training-lab101+ (this is the directory that contains the directory +data+)
 . Run the run configuration.
-.. _Quick open_ +4computer-12processes.xml+, _solve_ it and _terminate solving early_ after about 20 seconds.
+.. _Quick open_ +100computer-300processes.xml+, _solve_ it and _terminate solving early_ after about 20 seconds.
 .. Notice how the used network bandwidth heavily differs per computer (and that capacity clearly limits it):
 +
 image::cloudBalancing_100computers-300processes.png[]


### PR DESCRIPTION
In lab101-solution.adoc, fix annalist -> analyst

In lab103.adoc, fix a reference to the 4computer-12processes.xml dataset
where a reference to 100computer-300processes.xml was due.
